### PR TITLE
aligned sub-items inside the sub-menu

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -72,7 +72,7 @@ body {
 }
 
 .side-bar .menu .item .sub-menu a {
-  padding-left: 90px;
+  padding-left: 30px;
 }
 
 .side-bar .menu .item .sub-menu img {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/56751927/112297963-80592c00-8cbc-11eb-9729-d4a2fa4d601b.png)
Now:
![2021-03-24 16_11_25-EddieHub](https://user-images.githubusercontent.com/56751927/112298073-9ff05480-8cbc-11eb-858c-27721c55de73.png)

Fixed the padding-left of the sub-items.