### PR TITLE
resized the text at about page

### DIFF
--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -16,8 +16,8 @@ body {
 .about {
   margin-left: 10vmin;
   color: white;
-  font-size: 3vmax;
-  margin-top: 20vmin;
+  font-size: 1.5vmax;
+  margin-top: 15vmin;
   position: relative;
   transition: 0.6s ease;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/56751927/112429417-a33e1b80-8d62-11eb-85c4-484a4a554034.png)

Closes Issue #40 

I fixed the text size at the about page. And I also had to tweak around with the margin-top to make it look good. 